### PR TITLE
fix potentials conflicts between React router and Symfony router

### DIFF
--- a/src/Controller/MainController.php
+++ b/src/Controller/MainController.php
@@ -9,6 +9,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class MainController extends AbstractController
 {
     #[Route('/', name: 'app_main')]
+    #[Route('/{slug}', name: 'app_main_slug', requirements: ['slug' => '.+'], priority: -1)]
     public function index(): Response
     {
         return $this->render('main/index.html.twig');


### PR DESCRIPTION
J'ai fait quelques test là-dessus avec différentes routes déclarées sous React et sous Symfony.
Si aucun Controller PHP ne match avec la route, alors c'est l'appli React de la home qui récupère la requête.
Ce qui permet d'avoir accès à `/api` tout le temps entre-autres 😎 et de pouvoir déclarer ou pas d'autres routes Symfo.
Le pattern marche avec n'importe quelle profondeur d'url.